### PR TITLE
Release 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xoon-proto-gen-rust"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Overview
===

- Update xoon-proto to [19b9fa99a014af6281366c905a7f6d73fa39c787](https://github.com/pyama2000/xoon-proto-gen-rust/commit/19b9fa99a014af6281366c905a7f6d73fa39c787)
- Update crate version to 0.1.1
