### PR TITLE
Rename kintai service file descriptor and package name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "xoon-proto-gen-rust"
+name = "xoon_proto_gen_rust"
 version = "0.1.2"
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xoon_proto_gen_rust"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xoon_proto_gen_rust"
-version = "0.1.3"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod kintai_service {
     tonic::include_proto!("kintai.v1");
-    pub const FILE_DESCRIPTOR_SET: &[u8] =
+    pub const KINTAI_SERVICE_FILE_DESCRIPTOR_SET: &[u8] =
         tonic::include_file_descriptor_set!("kintai_service_descriptor");
 }


### PR DESCRIPTION
Overview
===

- Rename to `KINTAI_SERVICE_FILE_DESCRIPTOR_SET`
- Rename package name to `xoon_proto_gen_rust`
