### PR TITLE
Remove GetSlackChannelIds rpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xoon_proto_gen_rust"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Overview
===

Remove GetSlackChannelIds rpc

- Update xoon-proto
- Update package version to 0.1.6
