### PR TITLE
Fix module name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xoon_proto_gen_rust"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,17 @@
-pub mod kintai_service {
-    tonic::include_proto!("kintai.v1");
-    pub const KINTAI_SERVICE_FILE_DESCRIPTOR_SET: &[u8] =
-        tonic::include_file_descriptor_set!("kintai_service_descriptor");
+pub mod kintai {
+    pub mod v1 {
+        tonic::include_proto!("kintai.v1");
+        pub const KINTAI_SERVICE_FILE_DESCRIPTOR_SET: &[u8] =
+            tonic::include_file_descriptor_set!("kintai_service_descriptor");
+    }
 }
 
-pub mod notification_service {
-    tonic::include_proto!("notification.v1");
-    pub const NOTIFICATION_SERVICE_FILE_DESCRIPTOR_SET: &[u8] =
-        tonic::include_file_descriptor_set!("notification_service_descriptor");
+pub mod notification {
+    pub mod v1 {
+        tonic::include_proto!("notification.v1");
+        pub const NOTIFICATION_SERVICE_FILE_DESCRIPTOR_SET: &[u8] =
+            tonic::include_file_descriptor_set!("notification_service_descriptor");
+    }
 }
 
 pub mod automation {


### PR DESCRIPTION
# Overview

- Fix module name
- Update xoon-proto-gen-rust to 0.1.13
